### PR TITLE
fixed ZNVM_PREEXEC commands dont trigger nvm load if args present

### DIFF
--- a/znvm.sh
+++ b/znvm.sh
@@ -18,7 +18,7 @@ source "$ZNVM_PATH/znvm.conf.sh"
 znvm_contains_elem () {
   local e match="$1"
   shift
-  for e; do [[ "$e" == "$match" ]] && return 0; done
+  for e; do [[ "$match" =~ "$e\ +.*|$e" ]] && return 0; done
   return 1
 }
 


### PR DESCRIPTION
fixed #2  ZNVM_PREEXEC commands don't trigger ```load-nvm``` if args passed

changed the match to a regex that matches a typical bash command style